### PR TITLE
Adding additional access log

### DIFF
--- a/src/ExpressMiddlewares.js
+++ b/src/ExpressMiddlewares.js
@@ -15,21 +15,20 @@ class ExpressMiddlewares {
         const hostName = os.hostname();
         const serviceColor = process.env.SERVICE_COLOR || "unknown";
         const errorHandler = (request, response) => "error";
-        let optKeys = [];
-        let optKeysString = '';
+        const optKeys = [];
 
         // Check for additional access logs
-        if (opts && typeof opts === 'object') {
-          Object.keys(opts).forEach((key) => {
+        if (opts && typeof opts === "object") {
+          for (const key in opts) {
+            console.log(key);
             try {
-              morgan.token(key, typeof opts[key] === 'function' ? opts[key] : errorHandler);
+              morgan.token(key, typeof opts[key] === "function" ? opts[key] : errorHandler);
             }
             catch(err) {
               morgan.token(key, errorHandler);
             }
             optKeys.push(`\"${key}\": \":${key}\"`);
-          });
-          optKeysString = optKeys.length > 0 ? `${optKeys.join()},` : optKeysString;
+          }
         }
 
         morgan.token("host_name", function getHostName(request, response) {
@@ -123,7 +122,7 @@ class ExpressMiddlewares {
             " \"request_method\": \":method\", \"uri\": \":uri\", \"query_string\": \":query_string\"," +
             " \"response_time\": \":response-time\", \"protocol\": \":protocol\", \"server_name\": \":server_name\"," +
             " \"current_color\": \":service_color\", \"remote_client_id\": \":remote_client_id\", " +
-            optKeysString + " \"bytes_received\": \":bytes_received\" }",
+            `${optKeys.length ? optKeys.join() + ',' : optKeys.join()}` + " \"bytes_received\": \":bytes_received\" }",
             {});
     }
 

--- a/src/ExpressMiddlewares.js
+++ b/src/ExpressMiddlewares.js
@@ -121,7 +121,7 @@ class ExpressMiddlewares {
             " \"request_method\": \":method\", \"uri\": \":uri\", \"query_string\": \":query_string\"," +
             " \"response_time\": \":response-time\", \"protocol\": \":protocol\", \"server_name\": \":server_name\"," +
             " \"current_color\": \":service_color\", \"remote_client_id\": \":remote_client_id\", " +
-            `${optKeys.length ? optKeys.join() + ',' : optKeys.join()}` + " \"bytes_received\": \":bytes_received\" }",
+            `${optKeys.length ? " " + optKeys.join(", ") + "," : ""}` + " \"bytes_received\": \":bytes_received\" }",
             {});
     }
 

--- a/src/ExpressMiddlewares.js
+++ b/src/ExpressMiddlewares.js
@@ -20,7 +20,6 @@ class ExpressMiddlewares {
         // Check for additional access logs
         if (opts && typeof opts === "object") {
           for (const key in opts) {
-            console.log(key);
             try {
               morgan.token(key, typeof opts[key] === "function" ? opts[key] : errorHandler);
             }

--- a/src/ServiceLogger.js
+++ b/src/ServiceLogger.js
@@ -139,13 +139,13 @@ class ServiceLogger {
             }
     }
 
-    applyMiddlewareAccessLog(expressApp) {
+    applyMiddlewareAccessLog(expressApp, opts) {
 
         if(!expressApp || typeof expressApp !== "function"){
             throw new Error("[log4bro] ExpressApp is null or not an object, make sure you pass an instance of express() to applyMiddleware.");
         }
 
-        expressApp.use(Middlewares.accessLogMiddleware(this.serviceName, this.dockerMode));
+        expressApp.use(Middlewares.accessLogMiddleware(this.serviceName, this.dockerMode, opts));
         return expressApp;
     }
 


### PR DESCRIPTION
### Description
When calling `applyMiddlewareAccessLog` function to specify access log, you can extend it by passing option like the following format.
```js
{
  "token": handlerFunction
}
```

For example: 
```js
let logger = new log4bro(options);
logger.applyMiddlewareAccessLog(app, {
  "version" : function() {
    return request.headers.version || "0.0.1";
  }
});
``` 

### How to test
1. Create simple express endpoint with the initialization of the `log4bro`
2. Call `applyMiddlewareAccessLog`
3. Access the endpoint 