### PR TITLE
Add new header attribute to log it into client id

### DIFF
--- a/src/ExpressMiddlewares.js
+++ b/src/ExpressMiddlewares.js
@@ -89,6 +89,11 @@ class ExpressMiddlewares {
                     rcId = request.headers[AUTH_INFO_USER_ID];
                 }
 
+                if (request.headers[AUTH_REMOTE_CLIENT_ID])
+                {
+                    rcId = request.headers[AUTH_REMOTE_CLIENT_ID];
+                }
+
                 if (!rcId) {
                     rcId = "unknown";
                 }


### PR DESCRIPTION
See https://github.com/micro-tools/log4bro/issues/21

Add a new attribute header which will log a proper client id into the logging field for the client Id.
This will overwrite the uuid and/or the auth_client_info_id if it exists. 