### PR TITLE
Fix vulnerable sub dependency "node-forge" by updating its dependency…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log4bro",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "easy ELK logger with compliant output format, based on bunyan.",
   "main": "index.js",
   "scripts": {
@@ -48,6 +48,6 @@
     "request": "^2.88.2"
   },
   "optionalDependencies": {
-    "@google-cloud/logging-bunyan": "^3.0.0"
+    "@google-cloud/logging-bunyan": "^3.0.1"
   }
 }


### PR DESCRIPTION
… graph

The package node-forge before 0.10.0 is vulnerable to Prototype Pollution via the util.setPath function. Note: Version 0.10.0 is a breaking change removing the vulnerable functions.

See:
https://github.com/googleapis/google-p12-pem/commit/05d669805a44f21a12faa788052eeee38396e30c#diff-b9cfc7f2cdf78a7f4b91a753d10865a2